### PR TITLE
🐛 Pop returns its default value when the first key is missing.

### DIFF
--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -139,8 +139,8 @@ class Cut:
         return self.data.items()
 
     def pop(self, path: str, default: Any = None) -> Any:
-        parent, last_key = self._traverse(self.data, path)
         try:
+            parent, last_key = self._traverse(self.data, path)
             return parent.pop(last_key)
         except IndexError as error:
             if default is not None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -405,6 +405,10 @@ class TestPop:
 
         assert str(error.value) == str(expected_error)
 
+    def test_returns_default_when_key_is_undefined(self, proxy):
+        result = proxy.pop("trainer.bicycle", False)
+        assert result is False
+
     def test_when_index_is_undefined(self, proxy):
         with pytest.raises(IndexError) as error:
             proxy.pop("pokemon[42]")


### PR DESCRIPTION
Cf: #11 