### PR TITLE
Python version required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "scalpel",
         "wrapper",
     ],
+    python_requires=">=3.6",
     classifiers=[
         "Intended Audience :: Developers",
         "License :: Public Domain",


### PR DESCRIPTION
This package is not supported for python version `3.5` or lower
https://docs.python.org/3/reference/lexical_analysis.html#f-strings

Error with Python 3.5
```python
Traceback (most recent call last):
  File "/home/.../.../.../main.py", line 2, in <module>
    from scalpl import Cut
  File "/home/.../.../.../venv/lib/python3.5/site-packages/scalpl/__init__.py", line 1, in <module>
    from .scalpl import Cut
  File "/home/.../.../.../venv/lib/python3.5/site-packages/scalpl/scalpl.py", line 24
    f"Cannot access key '{failing_key}' in path '{original_path}',"
                                                                  ^
SyntaxError: invalid syntax
```