### PR TITLE
make Cut implicitly inherit an "object"

### DIFF
--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -83,7 +83,7 @@ def traverse(data: dict, keys: List[Union[str, int]], original_path: str):
     return value
 
 
-class Cut:
+class Cut(object):
     """
     Cut is a simple wrapper over the built-in dict class.
 

--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -119,9 +119,10 @@ class Cut:
 
         try:
             _ = item[last_key]
-            return True
         except (KeyError, IndexError):
             return False
+
+        return True
 
     def __delitem__(self, path: str) -> None:
         *keys, last_key = split_path(path, self.sep)

--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -68,6 +68,8 @@ def split_path(path: str, key_separator: str) -> TKeyList:
 
 def traverse(data: dict, keys: List[Union[str, int]], original_path: str):
     value = data
+    #: unlikely, but `key` can be referenced before assignment.
+    key = None
     try:
         for key in keys:
             value = value[key]
@@ -85,8 +87,8 @@ class Cut:
     """
     Cut is a simple wrapper over the built-in dict class.
 
-    It enables the standard dict API to operate on nested dictionnaries
-    and cut accross list item by using dot-separated string keys.
+    It enables the standard dict API to operate on nested dictionaries
+    and cut across list item by using dot-separated string keys.
 
     ex:
         query = {...} # Any dict structure
@@ -116,7 +118,7 @@ class Cut:
             return False
 
         try:
-            item[last_key]
+            _ = item[last_key]
             return True
         except (KeyError, IndexError):
             return False

--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -61,7 +61,7 @@ def split_path(path: str, key_separator: str) -> TKeyList:
                     "you can only provide integers to access list items."
                 )
             else:
-                raise ValueError(f"Key '{section}' is badly formated.")
+                raise ValueError(f"Key '{section}' is badly formatted.")
 
     return result
 


### PR DESCRIPTION
we should have the base class in the `class Cut(object)` - even if Python implicitly does that already.

```
class Foo:
    pass


class Bar(Foo):
    pass
``` 
vs:
```
class Foo(object):
    pass


class Bar(Foo):
    pass
```
    
seems to be much cleaner.